### PR TITLE
added auto margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ E.g.:
 * `.mh++` will give you a huge (`++`) horizontal (`h`) margin (`m`).
 * `.mb0` will give you no (`0`) margin (`m`) bottom (`b`).
 * `.pl-` will give you a small (`-`) padding (`p`) left (`l`).
+* `.mha` will give you an auto (`a`) horizontal (`h`) margin (`m`).
 
 Knowing these conventions means you can compose a huge array of spacing helpers.

--- a/_trumps.spacing.scss
+++ b/_trumps.spacing.scss
@@ -16,6 +16,7 @@ $inuit-margin:                          $inuit-base-spacing-unit !default;
 $inuit-padding:                         $inuit-base-spacing-unit !default;
 
 $inuit-enable-margins:                  false !default;
+$inuit-enable-margins--auto:            false !default;
 $inuit-enable-margins--tiny:            false !default;
 $inuit-enable-margins--small:           false !default;
 $inuit-enable-margins--large:           false !default;
@@ -56,6 +57,14 @@ $inuit-enable-paddings--none:           false !default;
     .#{$inuit-spacing-namespace}ml      { margin-left:      $inuit-margin !important; }
     .#{$inuit-spacing-namespace}mh      { margin-right:     $inuit-margin !important; margin-left:      $inuit-margin !important; }
     .#{$inuit-spacing-namespace}mv      { margin-top:       $inuit-margin !important; margin-bottom:    $inuit-margin !important; }
+
+    .#{$inuit-spacing-namespace}ma      { margin:        auto !important; }
+    .#{$inuit-spacing-namespace}mta     { margin-top:    auto !important; }
+    .#{$inuit-spacing-namespace}mra     { margin-right:  auto !important; }
+    .#{$inuit-spacing-namespace}mba     { margin-bottom: auto !important; }
+    .#{$inuit-spacing-namespace}mla     { margin-left:   auto !important; }
+    .#{$inuit-spacing-namespace}mha     { margin-right:  auto !important; margin-left:   auto !important; }
+    .#{$inuit-spacing-namespace}mva     { margin-top:    auto !important; margin-bottom: auto !important; }
 
 }
 
@@ -230,7 +239,20 @@ $inuit-enable-paddings--none:           false !default;
 }
 
 
+@if ($inuit-enable-margins--auto == true) {
+  
+    /**
+     * Auto margins.
+     */
 
+    .#{$inuit-spacing-namespace}ma  { margin:        auto !important; } 
+    .#{$inuit-spacing-namespace}mta { margin-top:    auto !important; }
+    .#{$inuit-spacing-namespace}mra { margin-right:  auto !important; }
+    .#{$inuit-spacing-namespace}mba { margin-bottom: auto !important; }
+    .#{$inuit-spacing-namespace}mla { margin-left:   auto !important; }
+    .#{$inuit-spacing-namespace}mha { margin-right:  auto !important; margin-left:   auto !important; }
+    .#{$inuit-spacing-namespace}mva { margin-top:    auto !important; margin-bottom: auto !important; }
+}
 
 
 @if ($inuit-enable-paddings == true) {

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,14 @@
 {
   "name": "inuit-spacing",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "homepage": "https://github.com/inuitcss/trumps.spacing",
   "authors": [
     "Harry Roberts <harry@csswizardry.com>"
   ],
+  "contributors": [{
+    "name": "twissell",
+    "mail": "mail@twissell.com"
+  }],
   "description": "Spacing helper classes in the inuitcss framework",
   "main": "_trumps.spacing.scss",
   "keywords": [


### PR DESCRIPTION
i added auto margins to trumps.spacing module in order to allow common patterns like `margin: 0 auto`, it uses the suffix `a` with all other classes. 